### PR TITLE
Fixes memory leak in nodeDump

### DIFF
--- a/.release-notes/29.md
+++ b/.release-notes/29.md
@@ -1,0 +1,3 @@
+## Fix memory leak in nodeDump
+
+Every call to `nodeDump` on an `Xml2Node` leaked memory. Long-running processes that repeatedly serialised node subtrees grew without bound. Memory is now reclaimed after each call.

--- a/libxml2/_test.pony
+++ b/libxml2/_test.pony
@@ -62,4 +62,5 @@ actor \nodoc\ Main is TestList
     test(TestComplexDocumentCreation)
     // Regression tests for memory-management fixes
     test(TestXPathResultPostFreeAccess)
+    test(TestNodeDumpRepeatedCalls)
 

--- a/libxml2/_tests/coverage_tests.pony
+++ b/libxml2/_tests/coverage_tests.pony
@@ -996,3 +996,53 @@ class \nodoc\ iso TestXPathResultPostFreeAccess is UnitTest
     else
       h.fail("Failed to exercise post-free XPath access")
     end
+
+class \nodoc\ iso TestNodeDumpRepeatedCalls is UnitTest
+  """
+  Regression test for the xmlBuffer free in nodeDump.
+
+  Each call allocates a temporary xmlBuffer, dumps into it, copies the
+  content into a Pony String, then frees the buffer. The returned strings
+  must remain intact across subsequent calls (no aliasing into the freed
+  buffer) and must contain the expected content (the copy must happen
+  before the free).
+
+  A regression that freed the buffer before extracting its content would
+  surface here as empty or corrupted strings. The original leak (buffer
+  never freed) is invisible to unit assertions and requires external
+  memory instrumentation to detect.
+  """
+  fun name(): String => "xml2node/nodedump-repeated"
+
+  fun apply(h: TestHelper) =>
+    let xml =
+      "<root><item id=\"a\">alpha</item><item id=\"b\">beta</item></root>"
+    try
+      let doc = Xml2Doc.parseDoc(xml)?
+      let root = doc.getRootElement()?
+      let children = root.getChildren()
+      h.assert_eq[USize](2, children.size())
+
+      // Capture dumps of two siblings, then verify they remain distinct
+      // and intact after subsequent calls allocate fresh buffers.
+      let first_dump: String val = children(0)?.nodeDump(0, 0)
+      let second_dump: String val = children(1)?.nodeDump(0, 0)
+      h.assert_eq[String]("<item id=\"a\">alpha</item>", first_dump)
+      h.assert_eq[String]("<item id=\"b\">beta</item>", second_dump)
+
+      // Sustained loop exercising allocate-and-free across many iterations.
+      var i: USize = 0
+      while i < 200 do
+        let dump = root.nodeDump(0, 0)
+        h.assert_eq[String](
+          "<root><item id=\"a\">alpha</item><item id=\"b\">beta</item></root>",
+          dump)
+        i = i + 1
+      end
+
+      // Earlier captures must still be intact after the loop.
+      h.assert_eq[String]("<item id=\"a\">alpha</item>", first_dump)
+      h.assert_eq[String]("<item id=\"b\">beta</item>", second_dump)
+    else
+      h.fail("Failed to exercise repeated nodeDump")
+    end

--- a/libxml2/xml2node.pony
+++ b/libxml2/xml2node.pony
@@ -224,12 +224,19 @@ class Xml2Node
     - `pformat`: Non-zero to enable formatted (indented) output, zero for
       unformatted.
 
-    Internally, creates a temporary `xmlBuffer`, dumps the node into it, and
-    returns the buffer's contents as a Pony `String`.
+    Internally, creates a temporary `xmlBuffer`, dumps the node into it,
+    copies the buffer's contents into a Pony `String`, then frees the
+    buffer. If `xmlBufferCreate` fails (OOM), returns an empty string
+    rather than passing a null buffer to libxml2.
     """
-    var buf: NullablePointer[XmlBuffer] = LibXML2.xmlBufferCreate()
+    let buf: NullablePointer[XmlBuffer] = LibXML2.xmlBufferCreate()
+    if buf.is_none() then
+      return ""
+    end
     LibXML2.xmlNodeDump(buf, ptr.doc, ptr', plevel, pformat)
-    LibXML2.xmlBufferContent(buf)
+    let result: String val = LibXML2.xmlBufferContent(buf)
+    LibXML2.xmlBufferFree(buf)
+    result
 
   fun ref appendChild(child: Xml2Node): Xml2Node ? =>
     """


### PR DESCRIPTION
xmlBufferCreate allocates a buffer that the caller must xmlBufferFree. Xml2Node.nodeDump never called the free, leaking the entire serialised subtree on every call. The wrapper also passed the result of xmlBufferCreate straight into xmlNodeDump with no null-check, so a buffer-allocation failure (OOM) caused a null deref inside libxml2 - contradicting the README's "safe from crashes" claim.

Captures the buffer in a local, null-checks before use (returning an empty string on allocation failure), copies the content into a Pony String, then frees the buffer before returning.

Adds a regression test that reads node dumps, captures them, runs many more nodeDump calls (each allocating and freeing a fresh buffer), then re-verifies the original captures are still intact. Catches any free-before-extract ordering regression; the leak itself remains invisible to unit assertions and requires external memory instrumentation to detect.