### PR TITLE
Fixes silent memory leak in serialize on allocator-lookup failure

### DIFF
--- a/.release-notes/30.md
+++ b/.release-notes/30.md
@@ -1,0 +1,3 @@
+## Fix silent memory leak in serialize on allocator-lookup failure
+
+If libxml2's internal allocator-function lookup ever failed during `serialize`, the call would silently leak the serialised buffer. The call now raises an error in that case rather than continuing on with a no-op free.

--- a/libxml2/xml2doc.pony
+++ b/libxml2/xml2doc.pony
@@ -307,6 +307,11 @@ class Xml2Doc
     var strdupFunc: Pointer[None] = Pointer[None]
     var rc: I32 = @xmlMemGet(addressof freeFunc, addressof mallocFunc, addressof reallocFunc, addressof strdupFunc)
 
+    // If xmlMemGet failed, freeFunc still holds the initial no-op lambda.
+    // Continuing would allocate a libxml2 buffer via the next call and then
+    // silently leak it when freeFunc(c_str) is invoked below. Raise instead.
+    if rc != 0 then error end
+
     // Call xmlDocDumpFormatMemoryEnc
     // format parameter: 1 for formatted, 0 for compact
     let format_val: I32 = if format then I32(1) else I32(0) end


### PR DESCRIPTION
Xml2Doc.serialize captured the return value of @xmlMemGet but never inspected it. If xmlMemGet ever failed (returned non-zero), freeFunc would retain its initial no-op lambda and the subsequent freeFunc(c_str) call would silently leak the libxml2-allocated serialised buffer. The condition is essentially unreachable in standard libxml2 builds (xmlMemGet just returns the configured allocator pointers), but the silent-leak-on-failure pattern matches the same class of defect as the xmlXPathObject and xmlBuffer leaks fixed in recent PRs.

Raises error when xmlMemGet returns non-zero, before the buffer allocation that would otherwise be unreclaimable.

No new test: the condition is unreachable from valid inputs and would require either patching libxml2 or mocking the FFI to exercise. Confirmed by inversion-counterfactual that the new branch is on every serialize call path; 12 existing tests that exercise serialize directly or transitively guard against accidental removal of the check.