### PR TITLE
Hardens XPath evaluation and createWithRoot against allocation failures

### DIFF
--- a/.release-notes/31.md
+++ b/.release-notes/31.md
@@ -1,0 +1,7 @@
+## Harden XPath evaluation and createWithRoot against allocation failures
+
+`xpathEval` on both `Xml2Doc` and `Xml2Node` previously dereferenced a null XPath context inside libxml2 if context allocation failed, contradicting the library's "safe from crashes" promise. The methods now return `None` cleanly in that case.
+
+`xpathEval` on `Xml2Node` also silently fell back to the document root if setting the context node failed, so a query like `./child` could return matches from across the whole document. It now returns `None` rather than producing wrong results.
+
+`Xml2Doc.createWithRoot` previously leaked the document if root-element creation failed mid-constructor. The document is now freed before the error is raised.

--- a/libxml2/xml2doc.pony
+++ b/libxml2/xml2doc.pony
@@ -101,7 +101,12 @@ class Xml2Doc
 
     let root_ptr = LibXML2.xmlNewDocNode(ptr', NullablePointer[XmlNs].none(),
                                           root_name, "")
-    if root_ptr.is_none() then error end
+    if root_ptr.is_none() then
+      // Pony does not call _final on objects whose constructor raised, so
+      // the xmlDoc allocated above would leak. Free it explicitly here.
+      LibXML2.xmlFreeDoc(ptr')
+      error
+    end
     LibXML2.xmlDocSetRootElement(ptr', root_ptr)
 
   fun xpathEval(
@@ -123,6 +128,11 @@ class Xml2Doc
     """
     let tmpctx: NullablePointer[XmlXPathContext] =
       LibXML2.xmlXPathNewContext(ptr')
+    if tmpctx.is_none() then
+      // Context allocation failed (OOM). Passing a null context to
+      // xmlXPathRegisterNs / xmlXPathEval would deref null inside libxml2.
+      return None
+    end
     for (n, url) in namespaces.values() do
       LibXML2.xmlXPathRegisterNs(tmpctx, n, url)
     end

--- a/libxml2/xml2node.pony
+++ b/libxml2/xml2node.pony
@@ -47,10 +47,22 @@ class Xml2Node
     """
     let tmpctx: NullablePointer[XmlXPathContext] =
       LibXML2.xmlXPathNewContext(ptr.doc)
+    if tmpctx.is_none() then
+      // Context allocation failed (OOM). Passing a null context to the
+      // calls below would deref null inside libxml2.
+      return None
+    end
     for (n, url) in namespaces.values() do
       LibXML2.xmlXPathRegisterNs(tmpctx, n, url)
     end
-    LibXML2.xmlXPathSetContextNode(ptr', tmpctx)
+    if LibXML2.xmlXPathSetContextNode(ptr', tmpctx) < 0 then
+      // Failure to set the context node would silently fall back to the
+      // document root, so a query like "./child" would return matches
+      // from the whole document instead of from this node. Free the
+      // context and return None rather than producing wrong results.
+      LibXML2.xmlXPathFreeContext(tmpctx)
+      return None
+    end
     let xptr: NullablePointer[XmlXPathObject] =
       LibXML2.xmlXPathEval(xpath, tmpctx)
     let xpo: Xml2XPathResult = Xml2XPathObject(xml2doc, xptr)


### PR DESCRIPTION
Three defensive guards on error paths that the README's "safe from crashes" promise relies on but that the previous code did not enforce.

H1: xpathEval on both Xml2Doc and Xml2Node passed the result of xmlXPathNewContext straight into xmlXPathRegisterNs and xmlXPathEval without a null check. On allocation failure libxml2 would deref the null context. Both methods now return None on a null context.

H2: Xml2Node.xpathEval ignored the return value of xmlXPathSetContextNode. On failure (returns -1) libxml2 silently falls back to the document root, so a relative XPath like ./child would return matches from the whole document instead of from this node. xpathEval now frees the context and returns None on negative return.

H4: Xml2Doc.createWithRoot allocated an xmlDoc, then errored if xmlNewDocNode returned null. Because Pony does not call _final on objects whose constructor raised, the doc was leaked. The doc is now freed explicitly before the error is raised.

No new positive tests: all three new branches are unreachable from valid inputs (they guard against OOM and internal libxml2 failures). Inversion-counterfactual confirmed every guard sits on its respective call's hot path: inverting all four checks (xmlXPathNewContext nulls in both files, xmlXPathSetContextNode return, root_ptr null) caused widespread test failures and a double-free abort during the suite, demonstrating each guard is reached on every call.