### PR TITLE
Adds crash-resistance fuzz tests for the Pony API

### DIFF
--- a/libxml2/_test.pony
+++ b/libxml2/_test.pony
@@ -1,4 +1,5 @@
 use "pony_test"
+use "pony_check"
 use "_tests"
 
 actor \nodoc\ Main is TestList
@@ -63,4 +64,12 @@ actor \nodoc\ Main is TestList
     // Regression tests for memory-management fixes
     test(TestXPathResultPostFreeAccess)
     test(TestNodeDumpRepeatedCalls)
+    // Crash-resistance fuzz tests (PonyCheck Property1)
+    test(Property1UnitTest[(String, String)](
+      recover iso FuzzCreateAndCreateElement end))
+    test(Property1UnitTest[(String, String)](
+      recover iso FuzzSetGetProp end))
+    test(Property1UnitTest[String](recover iso FuzzXPathExpression end))
+    test(Property1UnitTest[Array[String]](
+      recover iso FuzzAppendChildChain end))
 

--- a/libxml2/_tests/fuzz_tests.pony
+++ b/libxml2/_tests/fuzz_tests.pony
@@ -1,0 +1,177 @@
+use "../../libxml2"
+use "pony_test"
+use "pony_check"
+
+// Property-based "crash-resistance" tests for the Pony API surface.
+//
+// Each Property1 below feeds arbitrary input into a public entry point
+// and asserts two layered invariants:
+//
+//   * Outer fallible calls that take FIXED valid inputs (e.g.
+//     `Xml2Doc.create()?`, `Xml2Doc.createWithRoot("root")?`,
+//     `parseDoc("<root>...</root>")?`, `doc.serialize()?` where the
+//     test's contract requires it to succeed) are wrapped in
+//     `h.assert_no_error({() ? => ... } box)`. A regression that
+//     causes any of those to raise on a fixed valid input fails the
+//     test loudly with a localised PonyCheck assertion.
+//
+//   * Inner partial calls on FUZZED input (e.g. `createElement(name',
+//     content)?`, `appendChild(child)?`, `xpathEvalNodes(arg1)?`)
+//     stay inside a bare `try ... end`. The contract there is "may
+//     legitimately fail on hostile input"; only a process abort or
+//     segfault inside libxml2 / at the FFI boundary fails the test.
+//
+// This directly verifies the README's "If it crashes, it's a bug"
+// claim for the inputs the generators cover.
+//
+// What these tests CANNOT catch (by design):
+//   * Memory leaks (visible only under valgrind / leak sanitizer).
+//   * Silent wrong-result bugs (e.g. NUL-byte truncation in input).
+//     A truncated parse is still a "clean" completion as far as the
+//     test is concerned. Those bugs need targeted positive tests.
+//   * Inputs outside each generator's distribution (see balance note
+//     in pony-pbt-patterns rule 6).
+//   * Regressions that convert previously-successful calls on FUZZED
+//     input into spurious errors: those are swallowed by the inner
+//     `try ... end` by design.
+
+// NOTE: a FuzzParseDoc property was investigated and removed.
+// Feeding random byte strings, unicode_bmp strings, or even pure
+// ascii_letters strings to Xml2Doc.parseDoc reliably segfaults or
+// triggers a `free(): invalid pointer` abort after a handful of
+// failed parses. The crash is cumulative across inputs (a single
+// failed parse passes; ~5-10 distinct failed parses crash) but does
+// not reproduce when the same input is reparsed in a loop. The
+// underlying cause appears to be in libxml2's internal state
+// handling for repeated parse errors. The other fuzz tests below
+// avoid this by exercising APIs other than parseDoc, starting from
+// a fixed valid document or a freshly created one.
+
+class \nodoc\ iso FuzzCreateAndCreateElement is Property1[(String, String)]
+  """
+  Feed arbitrary names and content to `createElement` against a freshly
+  created document. Crash-resistance only: the test asserts that
+  `Xml2Doc.create()?` always succeeds, then tolerates `createElement?`
+  failures on hostile names while requiring the process to survive.
+  The created element is left orphan (not attached to the tree); a
+  follow-up property is needed to exercise attachment-and-access.
+  """
+  fun name(): String => "fuzz/create-element/property"
+
+  fun gen(): Generator[(String, String)] =>
+    Generators.zip2[String, String](
+      // Names: ASCII letters cover the "valid XML name" baseline plus
+      // some inputs that overlap libxml2's name validator boundary
+      // (empty, very short, longer than typical).
+      Generators.ascii_letters(0, 64),
+      // Content: arbitrary bytes (including NUL and invalid UTF-8) so
+      // libxml2's content handling is exercised at the boundary.
+      Generators.byte_string(Generators.u8(), 0, 256))
+
+  fun ref property(arg1: (String, String), h: PropertyHelper) =>
+    (let name', let content) = arg1
+    h.assert_no_error({() ? =>
+      let doc = Xml2Doc.create()?
+      try
+        let elem = doc.createElement(name', content)?
+        // Use the element so anything stored stale inside Xml2Node
+        // is exposed.
+        let _ = elem.name()
+      end
+    } box)
+
+class \nodoc\ iso FuzzSetGetProp is Property1[(String, String)]
+  """
+  Call `setProp` / `getProp` / `getProps` / `unsetProp` on a fresh
+  document's root element with arbitrary attribute names and values.
+  Crash-resistance only: the test asserts the doc construction
+  succeeds (fixed input "root") and the attribute calls do not crash
+  on hostile input. A stronger getProp/setProp round-trip property
+  (asserting `getProp(name) == value` for valid name + NUL-free value)
+  is left to a follow-up PBT pass.
+  """
+  fun name(): String => "fuzz/set-get-prop/property"
+
+  fun gen(): Generator[(String, String)] =>
+    Generators.zip2[String, String](
+      Generators.ascii_letters(0, 32),
+      Generators.byte_string(Generators.u8(), 0, 128))
+
+  fun ref property(arg1: (String, String), h: PropertyHelper) =>
+    (let prop_name, let prop_value) = arg1
+    h.assert_no_error({() ? =>
+      let doc = Xml2Doc.createWithRoot("root")?
+      let root = doc.getRootElement()?
+      // setProp / unsetProp / getProp / getProps are all non-partial;
+      // they cannot raise. They go inside the lambda only to share
+      // the doc/root lifetime with the partial calls above.
+      root.setProp(prop_name, prop_value)
+      let _ = root.getProp(prop_name)
+      let _ = root.getProps()
+      root.unsetProp(prop_name)
+    } box)
+
+class \nodoc\ iso FuzzXPathExpression is Property1[String]
+  """
+  Feed arbitrary strings as XPath expressions against a fixed valid
+  document. Crash-resistance only: the test asserts that parsing the
+  fixed document succeeds and that `xpathEval` (non-partial) does not
+  crash on hostile expressions. The partial convenience forms
+  `xpathEvalNodes?` / `xpathEvalString?` are allowed to raise on
+  invalid expressions and the raise is swallowed. The specific shape
+  of the rejection (None vs. error vs. value) is not asserted.
+  """
+  fun name(): String => "fuzz/xpath-expr/property"
+
+  fun gen(): Generator[String] =>
+    // ASCII printable covers the typical XPath character set plus
+    // weird-but-valid bytes; longer expressions stress libxml2's
+    // expression parser more than short ones.
+    Generators.ascii_printable(0, 128)
+
+  fun ref property(arg1: String, h: PropertyHelper) =>
+    h.assert_no_error({() ? =>
+      let doc = Xml2Doc.parseDoc(
+        "<root><a id=\"x\">one</a><b>two</b></root>")?
+      // Non-partial form must not crash regardless of input.
+      let _ = doc.xpathEval(arg1)
+      // Partial convenience forms may raise on invalid expressions.
+      try
+        let _ = doc.xpathEvalNodes(arg1)?
+      end
+      try
+        let _ = doc.xpathEvalString(arg1)?
+      end
+    } box)
+
+class \nodoc\ iso FuzzAppendChildChain is Property1[Array[String]]
+  """
+  Build a chain of element names and append them as nested children,
+  then serialize. The test asserts that doc construction and the
+  final `serialize()?` succeed; individual `createElement?` /
+  `appendChild?` failures on invalid names are tolerated (inner try).
+  The point is that the doc must remain serializable through a
+  sequence of mixed-validity append attempts; a half-built tree that
+  trips up libxml2's serializer would fail the `assert_no_error`.
+  """
+  fun name(): String => "fuzz/append-child-chain/property"
+
+  fun gen(): Generator[Array[String]] =>
+    Generators.seq_of[String, Array[String]](
+      Generators.ascii_letters(0, 16), 0, 16)
+
+  fun ref property(arg1: Array[String], h: PropertyHelper) =>
+    h.assert_no_error({() ? =>
+      let doc = Xml2Doc.createWithRoot("root")?
+      var parent = doc.getRootElement()?
+      for child_name in arg1.values() do
+        try
+          let child = doc.createElement(child_name, "")?
+          parent.appendChild(child)?
+          parent = child
+        end
+      end
+      // The doc must remain serializable regardless of how the chain
+      // of append attempts resolved; this is the load-bearing assertion.
+      let _ = doc.serialize()?
+    } box)


### PR DESCRIPTION
Four PonyCheck property tests verify the README's "If it crashes, it's a bug" claim across the public API:

  fuzz/create-element/property      - createElement with random names
                                      and content (incl. NUL bytes,
                                      invalid UTF-8)
  fuzz/set-get-prop/property        - setProp/getProp/unsetProp with
                                      random names and values
  fuzz/xpath-expr/property          - xpathEval with random ASCII
                                      printable expressions
  fuzz/append-child-chain/property  - createElement + appendChild
                                      chains of varying depth

Each property asserts two layered invariants. Outer fallible calls that take fixed valid inputs (Xml2Doc.create(), createWithRoot, parseDoc of a fixed valid doc, serialize) run inside h.assert_no_error so a regression on those surfaces as a localised PonyCheck failure. Inner partial calls on fuzzed input stay inside a bare try ... end; only a process abort or segfault fails the test.

A FuzzParseDoc property was investigated and removed. Feeding non-trivially varied non-XML inputs to Xml2Doc.parseDoc reliably segfaults or aborts with "free(): invalid pointer" after a handful of distinct failed parses. The crash is cumulative across inputs but does not reproduce when the same input is reparsed in a loop, suggesting state corruption in libxml2's internal handling of repeated parse errors. The in-file comment in fuzz_tests.pony preserves the investigation summary; the parseDoc crash is filed as separate follow-up work.

The other fuzz tests avoid this hazard by exercising APIs other than parseDoc, starting from a freshly created or fixed valid document.

No release note: test-only changes don't get user-facing entries in this project (cf. PRs #22 and #23 not in CHANGELOG).