### PR TITLE
Adds namespace-aware accessors to Xml2Node

### DIFF
--- a/.release-notes/33.md
+++ b/.release-notes/33.md
@@ -1,0 +1,18 @@
+## Add namespace-aware accessors to Xml2Node
+
+Adds four methods to `Xml2Node` for working with documents that use XML namespaces. `name()` continues to return the local name only.
+
+- `namespaceUri()`: the node's namespace URI, or `""` if the node has no namespace.
+- `namespacePrefix()`: the namespace prefix as written in the source document (e.g. `"glib"` for `<glib:signal>`), or `""` for the default namespace.
+- `qname()`: the qualified name as a `(namespace_uri, local_name)` tuple, for matching on both at once.
+- `getPropNs(uri, local)`: retrieves a namespace-qualified attribute by URI and local name, useful when a document binds the namespace under a non-conventional prefix.
+
+```pony
+let GLIB_NS: String = "http://www.gtk.org/introspection/glib/1.0"
+for child in class_node.getChildren().values() do
+  match child.qname()
+  | ("", "method")      => // <method>
+  | (GLIB_NS, "signal") => // <glib:signal>
+  end
+end
+```

--- a/libxml2/_test.pony
+++ b/libxml2/_test.pony
@@ -64,6 +64,10 @@ actor \nodoc\ Main is TestList
     // Regression tests for memory-management fixes
     test(TestXPathResultPostFreeAccess)
     test(TestNodeDumpRepeatedCalls)
+    // Namespace accessors (#33)
+    test(TestNamespaceUriAndPrefix)
+    test(TestQname)
+    test(TestGetPropNs)
     // Crash-resistance fuzz tests (PonyCheck Property1)
     test(Property1UnitTest[(String, String)](
       recover iso FuzzCreateAndCreateElement end))

--- a/libxml2/_tests/coverage_tests.pony
+++ b/libxml2/_tests/coverage_tests.pony
@@ -1046,3 +1046,155 @@ class \nodoc\ iso TestNodeDumpRepeatedCalls is UnitTest
     else
       h.fail("Failed to exercise repeated nodeDump")
     end
+
+class \nodoc\ iso TestNamespaceUriAndPrefix is UnitTest
+  """
+  Tests for Xml2Node.namespaceUri() and Xml2Node.namespacePrefix() on
+  elements with no namespace, a default namespace, and a prefixed
+  namespace.
+  """
+  fun name(): String => "xml2node/namespace-uri-and-prefix"
+
+  fun apply(h: TestHelper) =>
+    let xml =
+      """
+      <repository xmlns="http://www.gtk.org/introspection/core/1.0"
+                  xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+        <class>
+          <method/>
+          <glib:signal/>
+        </class>
+        <namespace-free xmlns=""/>
+      </repository>
+      """
+    try
+      let doc = Xml2Doc.parseDoc(xml)?
+      let repository = doc.getRootElement()?
+      // Root is in the default namespace - URI populated, prefix empty.
+      h.assert_eq[String](
+        "http://www.gtk.org/introspection/core/1.0",
+        repository.namespaceUri())
+      h.assert_eq[String]("", repository.namespacePrefix())
+
+      let children = repository.getChildren()
+      h.assert_eq[USize](2, children.size())
+      let class_node = children(0)?
+      let ns_free = children(1)?
+
+      // <class> inherits the default namespace.
+      h.assert_eq[String](
+        "http://www.gtk.org/introspection/core/1.0",
+        class_node.namespaceUri())
+      h.assert_eq[String]("", class_node.namespacePrefix())
+
+      let class_children = class_node.getChildren()
+      h.assert_eq[USize](2, class_children.size())
+      let method_node = class_children(0)?
+      let signal_node = class_children(1)?
+
+      // <method> is in the default namespace.
+      h.assert_eq[String]("method", method_node.name())
+      h.assert_eq[String](
+        "http://www.gtk.org/introspection/core/1.0",
+        method_node.namespaceUri())
+      h.assert_eq[String]("", method_node.namespacePrefix())
+
+      // <glib:signal> reports the glib URI AND the source-level prefix.
+      h.assert_eq[String]("signal", signal_node.name())
+      h.assert_eq[String](
+        "http://www.gtk.org/introspection/glib/1.0",
+        signal_node.namespaceUri())
+      h.assert_eq[String]("glib", signal_node.namespacePrefix())
+
+      // <namespace-free xmlns=""/> resets the default namespace to none.
+      h.assert_eq[String]("", ns_free.namespaceUri())
+      h.assert_eq[String]("", ns_free.namespacePrefix())
+    else
+      h.fail("Failed to parse XML or access namespace accessors")
+    end
+
+class \nodoc\ iso TestQname is UnitTest
+  """
+  Tests for Xml2Node.qname() returning (namespace_uri, local_name).
+  """
+  fun name(): String => "xml2node/qname"
+
+  fun apply(h: TestHelper) =>
+    let xml =
+      """
+      <root xmlns="http://example.com/default"
+            xmlns:c="http://example.com/c">
+        <plain/>
+        <c:typed/>
+      </root>
+      """
+    try
+      let doc = Xml2Doc.parseDoc(xml)?
+      let root = doc.getRootElement()?
+      let kids = root.getChildren()
+
+      // Direct tuple destructuring at the call site.
+      (let root_uri, let root_local) = root.qname()
+      h.assert_eq[String]("http://example.com/default", root_uri)
+      h.assert_eq[String]("root", root_local)
+
+      (let plain_uri, let plain_local) = kids(0)?.qname()
+      h.assert_eq[String]("http://example.com/default", plain_uri)
+      h.assert_eq[String]("plain", plain_local)
+
+      (let typed_uri, let typed_local) = kids(1)?.qname()
+      h.assert_eq[String]("http://example.com/c", typed_uri)
+      h.assert_eq[String]("typed", typed_local)
+    else
+      h.fail("Failed to parse XML or exercise qname")
+    end
+
+class \nodoc\ iso TestGetPropNs is UnitTest
+  """
+  Tests for Xml2Node.getPropNs(uri, local) resolving namespaced
+  attributes by URI. Verifies that the URI-based lookup works
+  regardless of which source-level prefix the document used to bind
+  the namespace.
+  """
+  fun name(): String => "xml2node/get-prop-ns"
+
+  fun apply(h: TestHelper) =>
+    // Use a non-conventional prefix ("capi" instead of "c") to confirm
+    // that getPropNs locates the attribute via its URI, not its prefix.
+    let xml =
+      """
+      <root xmlns:capi="http://www.gtk.org/introspection/c/1.0">
+        <field name="x" capi:type="gint" capi:identifier="x_field"/>
+      </root>
+      """
+    try
+      let doc = Xml2Doc.parseDoc(xml)?
+      let root = doc.getRootElement()?
+      let field = root.getChildren()(0)?
+
+      // Plain (non-namespaced) attribute still works via getProp.
+      h.assert_eq[String]("x", field.getProp("name"))
+
+      // Namespaced attributes retrieved by URI + local name.
+      h.assert_eq[String](
+        "gint",
+        field.getPropNs(
+          "http://www.gtk.org/introspection/c/1.0", "type"))
+      h.assert_eq[String](
+        "x_field",
+        field.getPropNs(
+          "http://www.gtk.org/introspection/c/1.0", "identifier"))
+
+      // Unknown namespace returns empty string.
+      h.assert_eq[String](
+        "",
+        field.getPropNs("http://not-a-real-namespace/", "type"))
+
+      // Known namespace, unknown local name returns empty string.
+      h.assert_eq[String](
+        "",
+        field.getPropNs(
+          "http://www.gtk.org/introspection/c/1.0", "nope"))
+    else
+      h.fail("Failed to parse XML or exercise getPropNs")
+    end

--- a/libxml2/xml2node.pony
+++ b/libxml2/xml2node.pony
@@ -112,12 +112,88 @@ class Xml2Node
 
   fun ref name(): String val =>
     """
-    Return this node’s name as a Pony `String`.
+    Return this node’s local name as a Pony `String`.
 
-    The name is obtained from the underlying `xmlNode->name` C string and
-    cloned into a Pony-managed string.
+    For an element written `<glib:signal>`, this returns `"signal"`. The
+    namespace prefix (if any) is reported separately by
+    `namespacePrefix()`. To distinguish elements with the same local
+    name in different namespaces, compare on both `namespaceUri()` and
+    `name()` (or use `qname()` for the pair).
     """
     String.from_cstring(ptr.name).clone()
+
+  fun ref namespaceUri(): String val =>
+    """
+    Return the namespace URI of this node, or an empty string if the
+    node has no namespace.
+
+    For `<glib:signal xmlns:glib="http://www.gtk.org/introspection/glib/1.0">`,
+    this returns `"http://www.gtk.org/introspection/glib/1.0"`. For
+    a node in no namespace, returns `""`.
+
+    Reads the URI from `xmlNode->ns->href` on the underlying node.
+    """
+    try
+      let ns: XmlNs = ptr.ns.apply()?
+      String.from_cstring(ns.href).clone()
+    else
+      ""
+    end
+
+  fun ref namespacePrefix(): String val =>
+    """
+    Return the namespace prefix as used in the source document (e.g.
+    `"glib"` for an element written as `<glib:signal>`), or an empty
+    string if the node is in the default namespace or has no
+    namespace.
+
+    The prefix is a source-level artifact; two namespaces with the
+    same URI may use different prefixes in different documents (or in
+    different scopes within the same document). For comparing
+    semantics across documents, use `namespaceUri()` instead.
+
+    Reads the prefix from `xmlNode->ns->prefix` on the underlying node.
+    """
+    try
+      let ns: XmlNs = ptr.ns.apply()?
+      String.from_cstring(ns.prefix).clone()
+    else
+      ""
+    end
+
+  fun ref qname(): (String val, String val) =>
+    """
+    Return the qualified name of this node as a tuple
+    `(namespace_uri, local_name)`.
+
+    Equivalent to `(namespaceUri(), name())`. Useful for matching on
+    both dimensions at once:
+
+    ```pony
+    match child.qname()
+    | ("", "method")      => // ...
+    | (glib_ns, "signal") => // ...
+    end
+    ```
+    """
+    (namespaceUri(), name())
+
+  fun ref getPropNs(uri: String, local: String): String =>
+    """
+    Get the value of an attribute on this element by namespace URI and
+    local name. Maps to libxml2’s `xmlGetNsProp`.
+
+    - `uri`: Namespace URI (e.g.
+      `"http://www.gtk.org/introspection/c/1.0"`).
+    - `local`: Local attribute name (without any prefix).
+
+    Returns the attribute value, or an empty string if no attribute
+    with that `(namespace, local)` pair is present on this element.
+    Unlike `getProp`, this resolves attributes by their URI rather
+    than by the source-level prefix, so it works correctly even when
+    a document binds the namespace under a non-conventional prefix.
+    """
+    LibXML2.xmlGetNsProp(ptr', local, uri)
 
   fun ref getLineNo(): I64 =>
     """


### PR DESCRIPTION
Closes #33. Adds four methods for working with namespaced XML, all backwards compatible:

  namespaceUri()    - the node's namespace URI, "" if none
  namespacePrefix() - the prefix as written in source, "" for default
  qname()           - (namespace_uri, local_name) tuple
  getPropNs(uri, local) - namespace-qualified attribute lookup

name() now documents that it returns only the local name; namespace distinction is via the new accessors. For elements written as <glib:signal>, name() returns "signal", namespacePrefix() returns "glib", and namespaceUri() returns the bound URI.

getPropNs wraps libxml2's xmlGetNsProp, resolving attributes by URI rather than by source-level prefix. This works correctly when a document binds the namespace under a non-conventional prefix (e.g. xmlns:capi="...c/1.0" still finds capi:type via the "c/1.0" URI).

Tests cover:
  - default namespace inheritance
  - explicit prefixed namespace (glib:signal)
  - namespace reset via xmlns="" on a child
  - qname() composition
  - getPropNs() with conventional and unknown URIs
  - getPropNs() with unknown local name in known URI

Counterfactual-verified each accessor independently catches its own regression class.