### PR TITLE
Adds parser options and safer parsing defaults

### DIFF
--- a/.release-notes/35.md
+++ b/.release-notes/35.md
@@ -1,0 +1,17 @@
+## Add parser options and safer parsing defaults
+
+`Xml2Doc.parseDoc` and `Xml2Doc.parseFile` now accept an optional `Xml2ParserOptions` argument and route through libxml2's `xmlReadDoc` / `xmlReadFile` internally. Without an explicit `options` argument they parse with **safe-by-default** settings: no network access (`XML_PARSE_NONET`), no entity substitution, no external DTD loading. This closes the XXE / SSRF attack surface for code parsing untrusted XML without forcing every caller to know to opt in.
+
+`Xml2ParserOptions` exposes typed boolean fields mapping 1:1 to libxml2's `XML_PARSE_*` flags: `error_recovery`, `substitute_entities`, `no_blanks`, `no_net`, `load_dtd`, `load_dtd_attrs`, `pedantic`, `huge`. Construct with `where` named arguments to override only the flags you need.
+
+```pony
+// Default: safe (no_net = true, substitute_entities = false)
+let doc = Xml2Doc.parseDoc(xml)?
+
+// Lenient parse that recovers from malformed input
+let opts = Xml2ParserOptions.create(
+  where error_recovery' = true, no_blanks' = true)
+let doc = Xml2Doc.parseDoc(xml, opts)?
+```
+
+**Behaviour change**: existing `parseDoc` / `parseFile` callers now parse with `XML_PARSE_NONET` enabled by default. Code that relied on libxml2's previous permissive defaults — in particular, on the parser fetching remote entities or DTDs — must explicitly opt in by constructing `Xml2ParserOptions.create(where no_net' = false, substitute_entities' = true, load_dtd' = true)`.

--- a/libxml2/_test.pony
+++ b/libxml2/_test.pony
@@ -68,6 +68,12 @@ actor \nodoc\ Main is TestList
     test(TestNamespaceUriAndPrefix)
     test(TestQname)
     test(TestGetPropNs)
+    // Parser options (#12)
+    test(TestParserOptionsDefaults)
+    test(TestParserOptionsFlagComposition)
+    test(TestParseDocNoBlanks)
+    test(TestParseDocErrorRecovery)
+    test(TestParseDocEntitiesNotSubstitutedByDefault)
     // Crash-resistance fuzz tests (PonyCheck Property1)
     test(Property1UnitTest[(String, String)](
       recover iso FuzzCreateAndCreateElement end))

--- a/libxml2/_tests/coverage_tests.pony
+++ b/libxml2/_tests/coverage_tests.pony
@@ -1198,3 +1198,175 @@ class \nodoc\ iso TestGetPropNs is UnitTest
     else
       h.fail("Failed to parse XML or exercise getPropNs")
     end
+
+class \nodoc\ iso TestParserOptionsDefaults is UnitTest
+  """
+  Verify that the default-constructed Xml2ParserOptions is
+  safe-by-default: no_net is enabled, entity substitution is disabled,
+  external DTD subset is not loaded.
+  """
+  fun name(): String => "xml2parseroptions/defaults"
+
+  fun apply(h: TestHelper) =>
+    let defaults = Xml2ParserOptions.create()
+    h.assert_eq[Bool](true,  defaults.no_net)
+    h.assert_eq[Bool](false, defaults.substitute_entities)
+    h.assert_eq[Bool](false, defaults.load_dtd)
+    h.assert_eq[Bool](false, defaults.load_dtd_attrs)
+    h.assert_eq[Bool](false, defaults.error_recovery)
+    h.assert_eq[Bool](false, defaults.no_blanks)
+    h.assert_eq[Bool](false, defaults.pedantic)
+    h.assert_eq[Bool](false, defaults.huge)
+    // to_flags() must include XML_PARSE_NONET (2048) and nothing else.
+    h.assert_eq[I32](2048, defaults.to_flags())
+
+class \nodoc\ iso TestParserOptionsFlagComposition is UnitTest
+  """
+  Verify that enabling multiple options OR's their bits correctly into
+  the flag bitmask passed to libxml2.
+  """
+  fun name(): String => "xml2parseroptions/flag-composition"
+
+  fun apply(h: TestHelper) =>
+    // Compose every flag set to true.
+    let all_on = Xml2ParserOptions.create(
+      where
+        error_recovery' = true,
+        substitute_entities' = true,
+        no_blanks' = true,
+        no_net' = true,
+        load_dtd' = true,
+        load_dtd_attrs' = true,
+        pedantic' = true,
+        huge' = true)
+    // Expected: 1 + 2 + 4 + 8 + 128 + 256 + 2048 + 524288
+    h.assert_eq[I32](526735, all_on.to_flags())
+
+    // Compose nothing.
+    let all_off = Xml2ParserOptions.create(
+      where no_net' = false)
+    h.assert_eq[I32](0, all_off.to_flags())
+
+    // Compose a typical "lenient parse" config.
+    let lenient = Xml2ParserOptions.create(
+      where error_recovery' = true, no_blanks' = true)
+    // 1 (RECOVER) + 256 (NOBLANKS) + 2048 (NONET) = 2305
+    h.assert_eq[I32](2305, lenient.to_flags())
+
+class \nodoc\ iso TestParseDocNoBlanks is UnitTest
+  """
+  no_blanks = true should cause libxml2 to discard ignorable whitespace
+  text nodes between elements. Without it, indentation produces text
+  nodes between element children.
+  """
+  fun name(): String => "xml2doc/parse-no-blanks"
+
+  fun apply(h: TestHelper) =>
+    let xml =
+      """
+      <root>
+        <a/>
+        <b/>
+        <c/>
+      </root>
+      """
+    try
+      // Default: blank text nodes preserved. getChildren() returns
+      // element-only children, so we can't distinguish via that API
+      // alone; instead, serialize and look for the indentation.
+      let doc_default = Xml2Doc.parseDoc(xml)?
+      let root_default = doc_default.getRootElement()?
+      let dump_default = root_default.nodeDump(0, 0)
+      // With blanks preserved, nodeDump output includes the original
+      // indentation between elements.
+      h.assert_true(dump_default.contains("\n  <a/>"))
+
+      // With no_blanks: ignorable whitespace dropped during parse.
+      // The serialized form has no inter-element whitespace.
+      let opts = Xml2ParserOptions.create(where no_blanks' = true)
+      let doc_no_blanks = Xml2Doc.parseDoc(xml, opts)?
+      let root_no_blanks = doc_no_blanks.getRootElement()?
+      let dump_no_blanks = root_no_blanks.nodeDump(0, 0)
+      h.assert_eq[String](
+        "<root><a/><b/><c/></root>", dump_no_blanks)
+    else
+      h.fail("Failed to parse XML")
+    end
+
+class \nodoc\ iso TestParseDocErrorRecovery is UnitTest
+  """
+  error_recovery = true should cause libxml2 to return a (partial)
+  document for malformed input that would otherwise fail to parse.
+  """
+  fun name(): String => "xml2doc/parse-error-recovery"
+
+  fun apply(h: TestHelper) =>
+    // Malformed: tag never closed.
+    let malformed = "<root><a><b></a>"
+
+    // Default: strict parse fails on this input.
+    try
+      let _ = Xml2Doc.parseDoc(malformed)?
+      h.fail("Default parse should have rejected malformed XML")
+    end
+
+    // error_recovery = true: parse succeeds, returning a doc that
+    // libxml2 reconstructed as best it could.
+    let opts = Xml2ParserOptions.create(where error_recovery' = true)
+    try
+      let doc = Xml2Doc.parseDoc(malformed, opts)?
+      let root = doc.getRootElement()?
+      // Whatever libxml2 recovers, the doc has a usable root.
+      h.assert_eq[String]("root", root.name())
+    else
+      h.fail("error_recovery should have allowed parse to succeed")
+    end
+
+class \nodoc\ iso TestParseDocEntitiesNotSubstitutedByDefault is UnitTest
+  """
+  By default, substitute_entities is false, so internal entity
+  references remain as entity-reference nodes in the document and are
+  preserved during serialization. With substitute_entities = true,
+  libxml2 expands them inline.
+
+  This guards the XXE-relevant defaults: a future regression that
+  enabled XML_PARSE_NOENT by accident would re-introduce the
+  attack surface for hostile inputs.
+  """
+  fun name(): String => "xml2doc/parse-entities-not-substituted-by-default"
+
+  fun apply(h: TestHelper) =>
+    let xml =
+      "<!DOCTYPE foo [<!ENTITY hello \"WORLD\">]><foo>&hello;</foo>"
+
+    // Default: entity reference preserved.
+    try
+      let doc = Xml2Doc.parseDoc(xml)?
+      let foo = doc.getRootElement()?
+      let dump = foo.nodeDump(0, 0)
+      h.assert_true(
+        dump.contains("&hello;"),
+        "expected entity reference to be preserved, got: " + dump)
+      h.assert_false(
+        dump.contains("WORLD"),
+        "entity value must not appear in element body, got: " + dump)
+    else
+      h.fail("Default parse of internal entity should have succeeded")
+    end
+
+    // substitute_entities = true: entity expanded inline.
+    let opts = Xml2ParserOptions.create(
+      where substitute_entities' = true)
+    try
+      let doc = Xml2Doc.parseDoc(xml, opts)?
+      let foo = doc.getRootElement()?
+      let dump = foo.nodeDump(0, 0)
+      h.assert_false(
+        dump.contains("&hello;"),
+        "entity ref must be gone after substitution, got: " + dump)
+      h.assert_true(
+        dump.contains("WORLD"),
+        "expected expanded value in element body, got: " + dump)
+    else
+      h.fail("substitute_entities parse should have succeeded")
+    end

--- a/libxml2/xml2doc.pony
+++ b/libxml2/xml2doc.pony
@@ -29,32 +29,51 @@ class Xml2Doc
   """
   let ptr': NullablePointer[XmlDoc]
 
-  new parseFile(auth: FileAuth, pfilename: String val) ? =>
+  new parseFile(
+    auth: FileAuth,
+    pfilename: String val,
+    options: Xml2ParserOptions val = Xml2ParserOptions.create()) ?
+  =>
     """
     Parse an XML document from the given file path using libxml2.
 
     - `auth`: Capability proving the caller has permission to read files.
     - `pfilename`: Path to the XML file to parse.
+    - `options`: Parser options controlling network access, entity
+      expansion, whitespace handling, and recovery behaviour. Defaults
+      to a safe-by-default `Xml2ParserOptions` (no network access, no
+      entity substitution). See `Xml2ParserOptions` for the full list.
 
-    On success, stores the underlying `xmlDoc*` in `ptr'` and its non-null
-    value in `ptr`. Raises an error if parsing fails or returns a null
-    document pointer.
+    Routes through libxml2's `xmlReadFile`, which is the
+    options-aware replacement for the legacy `xmlParseFile`. On
+    success, stores the underlying `xmlDoc*` in `ptr'`. Raises an
+    error if parsing fails or returns a null document pointer.
     """
-    let ptrx: NullablePointer[XmlDoc] = LibXML2.xmlParseFile(pfilename)
+    let ptrx: NullablePointer[XmlDoc] =
+      LibXML2.xmlReadFile(pfilename, "", options.to_flags())
     if ptrx.is_none() then error end
     ptr' = ptrx
 
-  new parseDoc(pcur: String val) ? =>
+  new parseDoc(
+    pcur: String val,
+    options: Xml2ParserOptions val = Xml2ParserOptions.create()) ?
+  =>
     """
     Parse an XML document from an in-memory string using libxml2.
 
     - `pcur`: String containing the complete XML document.
+    - `options`: Parser options controlling network access, entity
+      expansion, whitespace handling, and recovery behaviour. Defaults
+      to a safe-by-default `Xml2ParserOptions` (no network access, no
+      entity substitution). See `Xml2ParserOptions` for the full list.
 
-    On success, stores the underlying `xmlDoc*` in `ptr'` and its non-null
-    value in `ptr`. Raises an error if parsing fails or returns a null
-    document pointer.
+    Routes through libxml2's `xmlReadDoc`, which is the options-aware
+    replacement for the legacy `xmlParseDoc`. On success, stores the
+    underlying `xmlDoc*` in `ptr'`. Raises an error if parsing fails
+    or returns a null document pointer.
     """
-    let ptrx: NullablePointer[XmlDoc] = LibXML2.xmlParseDoc(pcur)
+    let ptrx: NullablePointer[XmlDoc] =
+      LibXML2.xmlReadDoc(pcur, "", "", options.to_flags())
     if ptrx.is_none() then error end
     ptr' = ptrx
 

--- a/libxml2/xml2parseroptions.pony
+++ b/libxml2/xml2parseroptions.pony
@@ -1,0 +1,106 @@
+class val Xml2ParserOptions
+  """
+  Options controlling XML document parsing. Each field maps 1:1 to a
+  libxml2 `XML_PARSE_*` flag in the bitmask consumed by `xmlReadDoc` /
+  `xmlReadFile`.
+
+  The default-constructed instance is **safe-by-default**:
+
+  - `no_net = true` — libxml2 must not perform any network access
+    while parsing (no remote DTD fetch, no remote entity expansion).
+    This is the primary mitigation against XXE / SSRF attacks on
+    parsing untrusted input.
+  - `substitute_entities = false` — internal and external entities
+    are not expanded into the document. Entity references remain as
+    `<xmlEntityRef>` nodes that the caller can choose to handle.
+  - `load_dtd = false`, `load_dtd_attrs = false` — external DTD
+    subset and default DTD attributes are not loaded.
+
+  To restore libxml2's historic permissive behaviour explicitly, set
+  `no_net = false` and `substitute_entities = true`.
+
+  Example — strict pretty-printing-friendly parsing:
+
+  ```pony
+  let opts = Xml2ParserOptions.create(
+    where no_blanks = true, pedantic = true)
+  let doc = Xml2Doc.parseDoc(xml, opts)?
+  ```
+  """
+
+  // Core (issue #12)
+  let error_recovery: Bool
+  let substitute_entities: Bool
+  let no_blanks: Bool
+
+  // Security
+  let no_net: Bool
+  let load_dtd: Bool
+  let load_dtd_attrs: Bool
+
+  // Mode
+  let pedantic: Bool
+  let huge: Bool
+
+  new val create(
+    error_recovery': Bool = false,
+    substitute_entities': Bool = false,
+    no_blanks': Bool = false,
+    no_net': Bool = true,
+    load_dtd': Bool = false,
+    load_dtd_attrs': Bool = false,
+    pedantic': Bool = false,
+    huge': Bool = false)
+  =>
+    """
+    Construct a parser options instance. All parameters default to the
+    safe-by-default settings described in the class docstring; pass
+    named arguments via `where` to opt into specific flags.
+
+    - `error_recovery'`: attempt to recover from malformed input
+      rather than failing the parse. Maps to `XML_PARSE_RECOVER`.
+      Named with the `error_` prefix because `recover` is a Pony
+      keyword.
+    - `substitute_entities'`: expand internal and external entities
+      into the document. Maps to `XML_PARSE_NOENT`. **Enabling this
+      on untrusted input reintroduces XXE.**
+    - `no_blanks'`: discard ignorable whitespace text nodes. Maps to
+      `XML_PARSE_NOBLANKS`.
+    - `no_net'`: forbid network access during parsing. Maps to
+      `XML_PARSE_NONET`. Defaults to `true`.
+    - `load_dtd'`: load the external DTD subset. Maps to
+      `XML_PARSE_DTDLOAD`. **Enabling this with `no_net = false` and
+      `substitute_entities = true` on untrusted input reintroduces
+      XXE / SSRF.**
+    - `load_dtd_attrs'`: apply default DTD attributes. Maps to
+      `XML_PARSE_DTDATTR`. Implies the DTD is loaded.
+    - `pedantic'`: enable strict (pedantic) error reporting. Maps to
+      `XML_PARSE_PEDANTIC`.
+    - `huge'`: relax libxml2's hard-coded size limits, allowing
+      documents larger than ~10 MB. Maps to `XML_PARSE_HUGE`.
+    """
+    error_recovery = error_recovery'
+    substitute_entities = substitute_entities'
+    no_blanks = no_blanks'
+    no_net = no_net'
+    load_dtd = load_dtd'
+    load_dtd_attrs = load_dtd_attrs'
+    pedantic = pedantic'
+    huge = huge'
+
+  fun to_flags(): I32 =>
+    """
+    Return the OR'd libxml2 `XML_PARSE_*` bitmask corresponding to
+    the enabled options. Consumed internally by `Xml2Doc.parseDoc` /
+    `parseFile` when calling `xmlReadDoc` / `xmlReadFile`.
+    """
+    var f: I32 = 0
+    if error_recovery      then f = f or 1 end       // XML_PARSE_RECOVER  = 1<<0
+    if substitute_entities then f = f or 2 end       // XML_PARSE_NOENT    = 1<<1
+    if load_dtd            then f = f or 4 end       // XML_PARSE_DTDLOAD  = 1<<2
+    if load_dtd_attrs      then f = f or 8 end       // XML_PARSE_DTDATTR  = 1<<3
+    if pedantic            then f = f or 128 end     // XML_PARSE_PEDANTIC = 1<<7
+    if no_blanks           then f = f or 256 end     // XML_PARSE_NOBLANKS = 1<<8
+    if no_net              then f = f or 2048 end    // XML_PARSE_NONET    = 1<<11
+    if huge                then f = f or 524288 end  // XML_PARSE_HUGE     = 1<<19
+    f


### PR DESCRIPTION
Closes #12. Replaces the internals of Xml2Doc.parseDoc / Xml2Doc.parseFile so they route through libxml2's options-aware xmlReadDoc / xmlReadFile, and adds an Xml2ParserOptions class for callers who need explicit control.

Both constructors gain an optional `options` parameter; without it they use a safe-by-default Xml2ParserOptions instance:

  no_net               = true   (XML_PARSE_NONET)
  substitute_entities  = false  (XML_PARSE_NOENT off)
  load_dtd             = false  (XML_PARSE_DTDLOAD off)
  load_dtd_attrs       = false  (XML_PARSE_DTDATTR off)

This is the review H6 fix: XXE / SSRF surface closed for all existing parseDoc / parseFile callers, not just those who knew to ask for safer parsing. Callers that rely on libxml2's previous permissive behaviour can restore it by passing an explicit options instance.

Xml2ParserOptions exposes typed boolean fields mapping 1:1 to libxml2 XML_PARSE_* flags. The `error_recovery` field is named with the `error_` prefix because `recover` is a Pony keyword.

Tests cover:
  - defaults are safe (no_net on, substitute_entities off, all other flags off; to_flags() == 2048)
  - to_flags() composition across the full flag set
  - no_blanks discards inter-element whitespace
  - error_recovery accepts malformed XML that strict parsing rejects
  - default parsing leaves internal entity references un-expanded, while substitute_entities = true expands them

Counterfactual: flipping the substitute_entities default to true fails three tests including the XXE-relevant behaviour assertion, confirming the safety defaults are covered from multiple angles.